### PR TITLE
Reporter configuration

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -20,9 +20,11 @@ lazy val errorsSummary =
       scalacOptions ++=
         Seq("-deprecation", "-feature", "-unchecked", "-Xlint", "-Ywarn-all"),
       licenses += ("MIT", url("http://opensource.org/licenses/MIT")),
-      libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.1" % Test
+      libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.1" % Test,
+      sourceManaged in (Compile, generateContrabands) := baseDirectory.value / "src" / "main" / "contraband-scala"
     )
     .settings(testVersions.flatMap(testSetup))
+    .enablePlugins(ContrabandPlugin)
     .dependsOn(testAPI % Test)
 
 lazy val testCompiler =

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,2 @@
-addSbtPlugin("me.lessis" % "bintray-sbt" % "0.3.0")
+addSbtPlugin("me.lessis"     % "bintray-sbt"    % "0.3.0")
+addSbtPlugin("org.scala-sbt" % "sbt-contraband" % "0.3.0-M7")

--- a/src/main/contraband-scala/sbt/errorssummary/ReporterConfig.scala
+++ b/src/main/contraband-scala/sbt/errorssummary/ReporterConfig.scala
@@ -1,0 +1,37 @@
+/**
+ * This code is generated using [[http://www.scala-sbt.org/contraband/ sbt-contraband]].
+ */
+// DO NOT EDIT MANUALLY
+package sbt.errorssummary
+final class ReporterConfig private (val colors: Boolean,
+                                    val shortenPaths: Boolean)
+    extends Serializable {
+
+  override def equals(o: Any): Boolean = o match {
+    case x: ReporterConfig =>
+      (this.colors == x.colors) && (this.shortenPaths == x.shortenPaths)
+    case _ => false
+  }
+  override def hashCode: Int = {
+    37 * (37 * (37 * (17 + "ReporterConfig".##) + colors.##) + shortenPaths.##)
+  }
+  override def toString: String = {
+    "ReporterConfig(" + colors + ", " + shortenPaths + ")"
+  }
+  protected[this] def copy(
+      colors: Boolean = colors,
+      shortenPaths: Boolean = shortenPaths): ReporterConfig = {
+    new ReporterConfig(colors, shortenPaths)
+  }
+  def withColors(colors: Boolean): ReporterConfig = {
+    copy(colors = colors)
+  }
+  def withShortenPaths(shortenPaths: Boolean): ReporterConfig = {
+    copy(shortenPaths = shortenPaths)
+  }
+}
+object ReporterConfig {
+
+  def apply(colors: Boolean, shortenPaths: Boolean): ReporterConfig =
+    new ReporterConfig(colors, shortenPaths)
+}

--- a/src/main/contraband/ReporterConfig.contra
+++ b/src/main/contraband/ReporterConfig.contra
@@ -1,0 +1,7 @@
+package sbt.errorssummary
+@target(Scala)
+
+type ReporterConfig {
+    colors: Boolean!
+    shortenPaths: Boolean!
+}

--- a/src/main/scala/sbt/errorssummary/ConciseReporter.scala
+++ b/src/main/scala/sbt/errorssummary/ConciseReporter.scala
@@ -15,9 +15,9 @@ import scala.compat.Platform.EOL
  * @param parent Another reporter that should also receive the messages.
  */
 private class ConciseReporter(logger: Logger,
-                              enableColors: Boolean,
                               base: String,
-                              parent: Option[Reporter])
+                              parent: Option[Reporter],
+                              config: ReporterConfig)
     extends Reporter {
 
   private val _problems = collection.mutable.ArrayBuffer.empty[Problem]
@@ -89,23 +89,29 @@ private class ConciseReporter(logger: Logger,
     problems.exists(_.severity == Severity.Warn)
 
   /**
-   * Returns the absolute path of `file` with `base` stripped.
+   * Returns the absolute path of `file` with `base` stripped, if the reporter
+   * if configured with `shortenPaths = true`.
    *
    * @param file The file whose path to show.
-   * @return The absolute path of `file` with `base` stripped.
+   * @return The absolute path of `file` with `base` stripped if `shortenPaths = true`,
+   *         or the original path otherwise.
    */
-  private def showPath(file: File): String =
-    Option(file).map(_.getAbsolutePath.stripPrefix(base)).getOrElse("Unknown")
+  private def showPath(file: File): String = {
+    val absolutePath = Option(file).map(_.getAbsolutePath).getOrElse("unknown")
+    if (config.shortenPaths) absolutePath.stripPrefix(base)
+    else absolutePath
+  }
 
   /**
-   * Shows `str` with color `color`.
+   * Shows `str` with color `color` if the reporter is configured with
+   * `colors = true`.
    *
    * @param color The color to use
    * @param str   The string to color.
-   * @return The colored string.
+   * @return The colored string if `colors = true`, `str` otherwise.
    */
   private def colored(color: String, str: String): String =
-    if (enableColors) s"${RESET}${color}${str}${RESET}"
+    if (config.colors) s"${RESET}${color}${str}${RESET}"
     else str
 
   /**

--- a/src/main/scala/sbt/errorssummary/Plugin.scala
+++ b/src/main/scala/sbt/errorssummary/Plugin.scala
@@ -15,13 +15,13 @@ object Plugin extends AutoPlugin {
       inConfig(Test)(reporterSettings)
 
   private val insideEmacs =
-    sys.props.contains("INSIDE_EMACS")
+    sys.env.contains("INSIDE_EMACS")
 
   private val inCI =
     System.console() == null ||
-      sys.props.get("CI").exists(_ == "true") ||
-      sys.props.get("CONTINUOUS_INTEGRATION").exists(_ == "true") ||
-      sys.props.contains("BUILD_NUMBER")
+      sys.env.get("CI").exists(_ == "true") ||
+      sys.env.get("CONTINUOUS_INTEGRATION").exists(_ == "true") ||
+      sys.env.contains("BUILD_NUMBER")
 
   private val reporterSettings =
     compilerReporter in compile := {

--- a/src/main/scala/sbt/errorssummary/Plugin.scala
+++ b/src/main/scala/sbt/errorssummary/Plugin.scala
@@ -10,33 +10,30 @@ object Plugin extends AutoPlugin {
   override def requires = sbt.plugins.JvmPlugin
   override def trigger  = allRequirements
 
+  object autoImport {
+    val reporterConfig: SettingKey[ReporterConfig] =
+      settingKey[ReporterConfig]("Configuration of the error reporter")
+  }
+  import autoImport._
+
+  override def globalSettings: Seq[Setting[_]] = Seq(
+    reporterConfig := ReporterConfig(colors = true, shortenPaths = false)
+  )
+
   override def projectSettings: Seq[Setting[_]] =
     inConfig(Compile)(reporterSettings) ++
       inConfig(Test)(reporterSettings)
 
-  private val insideEmacs =
-    sys.env.contains("INSIDE_EMACS")
-
-  private val inCI =
-    System.console() == null ||
-      sys.env.get("CI").exists(_ == "true") ||
-      sys.env.get("CONTINUOUS_INTEGRATION").exists(_ == "true") ||
-      sys.env.contains("BUILD_NUMBER")
-
-  private val reporterSettings =
+  private val reporterSettings = Seq(
     compilerReporter in compile := {
-      val parent = (compilerReporter in compile).value
-      val logger = streams.value.log
-
-      // Disable color in Emacs and CI
-      val enableColors = !(insideEmacs || inCI)
-
-      // We don't shorten paths if we're inside Emacs
-      val sourceDir =
-        if (insideEmacs) "" else sys.props("user.dir") + File.separator
+      val logger  = streams.value.log
+      val baseDir = sys.props("user.dir")
+      val parent  = (compilerReporter in compile).value
+      val config  = (reporterConfig in compile).value
 
       val reporter =
-        new ConciseReporter(logger, enableColors, sourceDir, parent)
+        new ConciseReporter(logger, baseDir, parent, config)
       Some(reporter)
     }
+  )
 }

--- a/src/test/scala/sbt/errorssummary/CompilerSpec.scala
+++ b/src/test/scala/sbt/errorssummary/CompilerSpec.scala
@@ -8,8 +8,14 @@ import org.scalatest.{FlatSpec, Matchers}
 trait CompilerSpec {
   protected val scalaVersion = sys.props("test.scala.version")
 
-  def compile(reporter: Reporter, code: String, options: String*): Unit = {
+  def compile(reporter: Reporter, code: String, options: String*): Unit =
+    compile(reporter, code, options, "/tmp/src.scala")
+
+  def compile(reporter: Reporter,
+              code: String,
+              options: Seq[String],
+              path: String): Unit = {
     val compiler = CompilerLoader.load(reporter)
-    compiler.compile(code, options: _*)
+    compiler.compile(code, options.toArray, path)
   }
 }

--- a/src/test/scala/sbt/errorssummary/ConciseReporterSpec.scala
+++ b/src/test/scala/sbt/errorssummary/ConciseReporterSpec.scala
@@ -5,11 +5,17 @@ import xsbti.Problem
 
 trait ConciseReporterSpec { self: CompilerSpec =>
 
-  def collectMessagesFor[T](code: String)(
+  private val defaultConfig: ReporterConfig =
+    ReporterConfig(colors = false, shortenPaths = false)
+
+  def collectMessagesFor[T](code: String,
+                            config: ReporterConfig = defaultConfig,
+                            filePath: String = "/tmp/src.scala",
+                            base: String = "/tmp/")(
       fn: (Array[Problem], Seq[(Level.Value, String)]) => T): T = {
     val logger   = new RecordingLogger
-    val reporter = new ConciseReporter(logger, false, "", None)
-    compile(reporter, code)
+    val reporter = new ConciseReporter(logger, base, None, config)
+    compile(reporter, code, Seq.empty, filePath)
     reporter.printSummary()
     fn(reporter.problems, logger.getAll())
   }

--- a/src/test/scala/sbt/errorssummary/SelfSpec.scala
+++ b/src/test/scala/sbt/errorssummary/SelfSpec.scala
@@ -82,6 +82,20 @@ class SelfSpec extends FlatSpec with Matchers with CompilerSpec {
     }
   }
 
+  it should "set the sourcefile" in {
+    val code       = """error"""
+    val reporter   = new BasicReporter
+    val sourceFile = "/foo/bar/src.scala"
+    compile(reporter, code, Seq.empty, sourceFile)
+
+    reporter.problems should have length 1
+    val problem = reporter.problems()(0)
+    problem.position.sourceFile.isDefined shouldBe true
+    problem.position.sourceFile.get shouldBe file(sourceFile)
+    problem.position.sourcePath.isDefined shouldBe true
+    problem.position.sourcePath.get shouldBe sourceFile
+  }
+
   private class BasicReporter extends xsbti.Reporter {
     val msgs: Buffer[(Severity, Position, String)] = Buffer.empty
 

--- a/test-api/src/main/java/cross/CompilerAPI.java
+++ b/test-api/src/main/java/cross/CompilerAPI.java
@@ -1,5 +1,5 @@
 package cross;
 
 public interface CompilerAPI {
-    void compile(String code, String... options);
+    void compile(String code, String options[], String filePath);
 }


### PR DESCRIPTION
Currently, it supports only 2 configuration options:

 * `colors`, which controls whether the reporter should use colors to
   emphasize some parts of the error report.
 * `shortenPaths`, which controls whether the reporter will relativize
   file paths to the current working directory.

The configuration for the reporter can be set like this:

```
reporterConfig in (Compile, compile) := ReporterConfig(colors = false, shortenPaths = false)
reporterConfig in (Test, compile) := ReporterConfig(colors = true, shortenPaths = true)
```

This would result in different reporter configurations used to compile
the main and test targets.