### PR TITLE
Add config option to show column numbers

### DIFF
--- a/src/main/contraband-scala/sbt/errorssummary/ReporterConfig.scala
+++ b/src/main/contraband-scala/sbt/errorssummary/ReporterConfig.scala
@@ -4,24 +4,26 @@
 // DO NOT EDIT MANUALLY
 package sbt.errorssummary
 final class ReporterConfig private (val colors: Boolean,
-                                    val shortenPaths: Boolean)
+                                    val shortenPaths: Boolean,
+                                    val columnNumbers: Boolean)
     extends Serializable {
 
   override def equals(o: Any): Boolean = o match {
     case x: ReporterConfig =>
-      (this.colors == x.colors) && (this.shortenPaths == x.shortenPaths)
+      (this.colors == x.colors) && (this.shortenPaths == x.shortenPaths) && (this.columnNumbers == x.columnNumbers)
     case _ => false
   }
   override def hashCode: Int = {
-    37 * (37 * (37 * (17 + "ReporterConfig".##) + colors.##) + shortenPaths.##)
+    37 * (37 * (37 * (37 * (17 + "ReporterConfig".##) + colors.##) + shortenPaths.##) + columnNumbers.##)
   }
   override def toString: String = {
-    "ReporterConfig(" + colors + ", " + shortenPaths + ")"
+    "ReporterConfig(" + colors + ", " + shortenPaths + ", " + columnNumbers + ")"
   }
   protected[this] def copy(
       colors: Boolean = colors,
-      shortenPaths: Boolean = shortenPaths): ReporterConfig = {
-    new ReporterConfig(colors, shortenPaths)
+      shortenPaths: Boolean = shortenPaths,
+      columnNumbers: Boolean = columnNumbers): ReporterConfig = {
+    new ReporterConfig(colors, shortenPaths, columnNumbers)
   }
   def withColors(colors: Boolean): ReporterConfig = {
     copy(colors = colors)
@@ -29,9 +31,14 @@ final class ReporterConfig private (val colors: Boolean,
   def withShortenPaths(shortenPaths: Boolean): ReporterConfig = {
     copy(shortenPaths = shortenPaths)
   }
+  def withColumnNumbers(columnNumbers: Boolean): ReporterConfig = {
+    copy(columnNumbers = columnNumbers)
+  }
 }
 object ReporterConfig {
 
-  def apply(colors: Boolean, shortenPaths: Boolean): ReporterConfig =
-    new ReporterConfig(colors, shortenPaths)
+  def apply(colors: Boolean,
+            shortenPaths: Boolean,
+            columnNumbers: Boolean): ReporterConfig =
+    new ReporterConfig(colors, shortenPaths, columnNumbers)
 }

--- a/src/main/contraband/ReporterConfig.contra
+++ b/src/main/contraband/ReporterConfig.contra
@@ -4,4 +4,5 @@ package sbt.errorssummary
 type ReporterConfig {
     colors: Boolean!
     shortenPaths: Boolean!
+    columnNumbers: Boolean!
 }

--- a/src/main/scala/sbt/errorssummary/Plugin.scala
+++ b/src/main/scala/sbt/errorssummary/Plugin.scala
@@ -17,7 +17,9 @@ object Plugin extends AutoPlugin {
   import autoImport._
 
   override def globalSettings: Seq[Setting[_]] = Seq(
-    reporterConfig := ReporterConfig(colors = true, shortenPaths = false)
+    reporterConfig := ReporterConfig(colors = true,
+                                     shortenPaths = true,
+                                     columnNumbers = false)
   )
 
   override def projectSettings: Seq[Setting[_]] =

--- a/src/test/scala/sbt/errorssummary/BasicConciseReporterSpec.scala
+++ b/src/test/scala/sbt/errorssummary/BasicConciseReporterSpec.scala
@@ -65,8 +65,8 @@ class BasicConciseReporterSpec
 
   it should "respect colors setting" in {
     val code                = """error"""
-    val configWithColors    = ReporterConfig(colors = true, shortenPaths = false)
-    val configWithoutColors = configWithColors.withColors(false)
+    val configWithColors    = defaultConfig.withColors(true)
+    val configWithoutColors = defaultConfig.withColors(false)
     val expectedText        = "[1] /tmp/src.scala:1:"
 
     collectMessagesFor(code, configWithColors) { (problems, messages) =>
@@ -89,28 +89,59 @@ class BasicConciseReporterSpec
   }
 
   it should "strip prefix if told to" in {
-    val code = """error"""
-    val configWithFullPaths =
-      ReporterConfig(colors = false, shortenPaths = true)
-    val expectedText = "[1] src.scala:1:"
+    val code                     = """error"""
+    val configWithShortenedPaths = defaultConfig.withShortenPaths(true)
+    val expectedText             = "[1] src.scala:1:"
 
-    collectMessagesFor(code, configWithFullPaths) { (problems, messages) =>
-      problems should have length 1
+    collectMessagesFor(code, configWithShortenedPaths) {
+      (problems, messages) =>
+        problems should have length 1
 
-      messages should have length 2
-      val (_, msg) = messages.head
-      val lines    = msg.split(EOL)
-      lines(0) shouldBe expectedText
+        messages should have length 2
+        val (_, msg) = messages.head
+        val lines    = msg.split(EOL)
+        lines(0) shouldBe expectedText
     }
   }
 
   it should "not strip prefix if told not to" in {
-    val code = """error"""
-    val configWithoutFullPaths =
-      ReporterConfig(colors = false, shortenPaths = false)
-    val expectedText = "[1] /tmp/src.scala:1:"
+    val code                        = """error"""
+    val configWithoutShortenedPaths = defaultConfig.withShortenPaths(false)
+    val expectedText                = "[1] /tmp/src.scala:1:"
 
-    collectMessagesFor(code, configWithoutFullPaths) { (problems, messages) =>
+    collectMessagesFor(code, configWithoutShortenedPaths) {
+      (problems, messages) =>
+        problems should have length 1
+
+        messages should have length 2
+        val (_, msg) = messages.head
+        val lines    = msg.split(EOL)
+        lines(0) shouldBe expectedText
+    }
+  }
+
+  it should "not show colum numbers when told not to" in {
+    val code                       = """error"""
+    val configWithoutColumnNumbers = defaultConfig.withColumnNumbers(false)
+    val expectedText               = "[1] /tmp/src.scala:1:"
+
+    collectMessagesFor(code, configWithoutColumnNumbers) {
+      (problems, messages) =>
+        problems should have length 1
+
+        messages should have length 2
+        val (_, msg) = messages.head
+        val lines    = msg.split(EOL)
+        lines(0) shouldBe expectedText
+    }
+  }
+
+  it should "show colum numbers when told to" in {
+    val code                    = """    error""".stripMargin
+    val configWithColumnNumbers = defaultConfig.withColumnNumbers(true)
+    val expectedText            = "[1] /tmp/src.scala:1:5:"
+
+    collectMessagesFor(code, configWithColumnNumbers) { (problems, messages) =>
       problems should have length 1
 
       messages should have length 2

--- a/src/test/scala/sbt/errorssummary/ConciseReporterSpec.scala
+++ b/src/test/scala/sbt/errorssummary/ConciseReporterSpec.scala
@@ -5,8 +5,8 @@ import xsbti.Problem
 
 trait ConciseReporterSpec { self: CompilerSpec =>
 
-  private val defaultConfig: ReporterConfig =
-    ReporterConfig(colors = false, shortenPaths = false)
+  val defaultConfig: ReporterConfig =
+    ReporterConfig(colors = false, shortenPaths = false, columnNumbers = false)
 
   def collectMessagesFor[T](code: String,
                             config: ReporterConfig = defaultConfig,


### PR DESCRIPTION
This can be achieved by enabling it in the reporter config:

```
set reporterConfig := reporterConfig.value.withColumnNumbers(true)
```

Fixes #14