### PR TITLE
Fix #26 & #12: report line and column numbers on left of code and visually differentiate them

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,22 +14,23 @@ Side by side comparison (this plugin on the left, origin on the right):
 
 ```
 [info] Compiling 2 Scala sources to /Users/martin/Desktop/foo/target/scala-2.12/classes...
-[error] [1] src/main/scala/Bar.scala:2:
-[error]     type mismatch;
-[error]      found   : String("")
-[error]      required: Int
-[error]       val x: Int = ""
-[error]                    ^
-[warn]  [2] src/main/scala/Bar.scala:4:
-[warn]      @deprecated now takes two arguments; see the scaladoc.
-[warn]        @deprecated
-[warn]         ^
-[error] [3] src/main/scala/Foo.scala:2:
-[error]     not found: value foobar
-[error]       def foo: String = foobar
-[error]                         ^
-[error] src/main/scala/Bar.scala: 2 [1], 4 [2]
-[error] src/main/scala/Foo.scala: 2 [3]
+[error] [E1] src/main/scala/Bar.scala
+[error]      type mismatch;
+[error]       found   : String("")
+[error]       required: Int
+[error]      L2:  val x: Int = ""
+[error]      L2:               ^
+[warn]  [E2] src/main/scala/Bar.scala
+[warn]       @deprecated now takes two arguments; see the scaladoc.
+[warn]       L4:  @deprecated
+[warn]       L4:   ^
+[error] [E3] src/main/scala/Foo.scala
+[error]      not found: value foobar
+[error]      L2:  def foo: String = foobar
+[error]      L2:                    ^
+[error] src/main/scala/Bar.scala: L2 [E1], L4 [E2]
+[error] src/main/scala/Foo.scala: L2 [E3]
+[info] Legend: Ln = line n, Cn = column n, En = error n
 [error] (compile:compileIncremental) Compilation failed
 [error] Total time: 0 s, completed Jul 3, 2017 3:00:27 PM
 ```
@@ -98,6 +99,16 @@ The supported configuration options include:
    Example:
    ```scala
    reporterConfig := reporterConfig.value.withReverseOrder(false)
+   ```
+
+ - `showLegend: Boolean = true`:
+   Determines whether to show a legend at the bottom for the various
+   types of numbers (line, column, error). Note that despite this
+   setting, a legend will still only be shown if there actually are
+   errors, and not otherwise.
+   Example:
+   ```scala
+   reporterConfig := reporterConfig.value.withShowLegend(false)
    ```
 
 # Changelog

--- a/src/main/contraband-scala/sbt/errorssummary/ReporterConfig.scala
+++ b/src/main/contraband-scala/sbt/errorssummary/ReporterConfig.scala
@@ -7,6 +7,7 @@ final class ReporterConfig private (val colors: Boolean,
                                     val shortenPaths: Boolean,
                                     val columnNumbers: Boolean,
                                     val reverseOrder: Boolean,
+                                    val showLegend: Boolean,
                                     val errorColor: String,
                                     val warningColor: String,
                                     val infoColor: String,
@@ -20,6 +21,7 @@ final class ReporterConfig private (val colors: Boolean,
          true,
          false,
          false,
+         true,
          scala.Console.RED,
          scala.Console.YELLOW,
          scala.Console.CYAN,
@@ -34,6 +36,7 @@ final class ReporterConfig private (val colors: Boolean,
       shortenPaths,
       columnNumbers,
       false,
+      true,
       scala.Console.RED,
       scala.Console.YELLOW,
       scala.Console.CYAN,
@@ -44,20 +47,21 @@ final class ReporterConfig private (val colors: Boolean,
 
   override def equals(o: Any): Boolean = o match {
     case x: ReporterConfig =>
-      (this.colors == x.colors) && (this.shortenPaths == x.shortenPaths) && (this.columnNumbers == x.columnNumbers) && (this.reverseOrder == x.reverseOrder) && (this.errorColor == x.errorColor) && (this.warningColor == x.warningColor) && (this.infoColor == x.infoColor) && (this.debugColor == x.debugColor) && (this.sourcePathColor == x.sourcePathColor) && (this.errorIdColor == x.errorIdColor)
+      (this.colors == x.colors) && (this.shortenPaths == x.shortenPaths) && (this.columnNumbers == x.columnNumbers) && (this.reverseOrder == x.reverseOrder) && (this.showLegend == x.showLegend) && (this.errorColor == x.errorColor) && (this.warningColor == x.warningColor) && (this.infoColor == x.infoColor) && (this.debugColor == x.debugColor) && (this.sourcePathColor == x.sourcePathColor) && (this.errorIdColor == x.errorIdColor)
     case _ => false
   }
   override def hashCode: Int = {
-    37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (17 + "ReporterConfig".##) + colors.##) + shortenPaths.##) + columnNumbers.##) + reverseOrder.##) + errorColor.##) + warningColor.##) + infoColor.##) + debugColor.##) + sourcePathColor.##) + errorIdColor.##)
+    37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (17 + "ReporterConfig".##) + colors.##) + shortenPaths.##) + columnNumbers.##) + reverseOrder.##) + showLegend.##) + errorColor.##) + warningColor.##) + infoColor.##) + debugColor.##) + sourcePathColor.##) + errorIdColor.##)
   }
   override def toString: String = {
-    "ReporterConfig(" + colors + ", " + shortenPaths + ", " + columnNumbers + ", " + reverseOrder + ", " + errorColor + ", " + warningColor + ", " + infoColor + ", " + debugColor + ", " + sourcePathColor + ", " + errorIdColor + ")"
+    "ReporterConfig(" + colors + ", " + shortenPaths + ", " + columnNumbers + ", " + reverseOrder + ", " + showLegend + ", " + errorColor + ", " + warningColor + ", " + infoColor + ", " + debugColor + ", " + sourcePathColor + ", " + errorIdColor + ")"
   }
   protected[this] def copy(
       colors: Boolean = colors,
       shortenPaths: Boolean = shortenPaths,
       columnNumbers: Boolean = columnNumbers,
       reverseOrder: Boolean = reverseOrder,
+      showLegend: Boolean = showLegend,
       errorColor: String = errorColor,
       warningColor: String = warningColor,
       infoColor: String = infoColor,
@@ -68,6 +72,7 @@ final class ReporterConfig private (val colors: Boolean,
                        shortenPaths,
                        columnNumbers,
                        reverseOrder,
+                       showLegend,
                        errorColor,
                        warningColor,
                        infoColor,
@@ -86,6 +91,9 @@ final class ReporterConfig private (val colors: Boolean,
   }
   def withReverseOrder(reverseOrder: Boolean): ReporterConfig = {
     copy(reverseOrder = reverseOrder)
+  }
+  def withShowLegend(showLegend: Boolean): ReporterConfig = {
+    copy(showLegend = showLegend)
   }
   def withErrorColor(errorColor: String): ReporterConfig = {
     copy(errorColor = errorColor)
@@ -113,6 +121,7 @@ object ReporterConfig {
                        true,
                        false,
                        false,
+                       true,
                        scala.Console.RED,
                        scala.Console.YELLOW,
                        scala.Console.CYAN,
@@ -127,6 +136,7 @@ object ReporterConfig {
       shortenPaths,
       columnNumbers,
       false,
+      true,
       scala.Console.RED,
       scala.Console.YELLOW,
       scala.Console.CYAN,
@@ -138,6 +148,7 @@ object ReporterConfig {
             shortenPaths: Boolean,
             columnNumbers: Boolean,
             reverseOrder: Boolean,
+            showLegend: Boolean,
             errorColor: String,
             warningColor: String,
             infoColor: String,
@@ -148,6 +159,7 @@ object ReporterConfig {
                        shortenPaths,
                        columnNumbers,
                        reverseOrder,
+                       showLegend,
                        errorColor,
                        warningColor,
                        infoColor,

--- a/src/main/contraband/ReporterConfig.contra
+++ b/src/main/contraband/ReporterConfig.contra
@@ -6,6 +6,7 @@ type ReporterConfig {
     shortenPaths: Boolean!   = true                          @since("0.0.1")
     columnNumbers: Boolean!  = false                         @since("0.0.1")
     reverseOrder: Boolean!   = false                         @since("0.5.0")
+    showLegend: Boolean!     = true                          @since("0.5.0")
     errorColor: String!      = raw"scala.Console.RED"        @since("0.5.0")
     warningColor: String!    = raw"scala.Console.YELLOW"     @since("0.5.0")
     infoColor: String!       = raw"scala.Console.CYAN"       @since("0.5.0")

--- a/src/main/scala/sbt/errorssummary/ConciseReporter.scala
+++ b/src/main/scala/sbt/errorssummary/ConciseReporter.scala
@@ -67,7 +67,8 @@ private class ConciseReporter(logger: Logger,
           }
       }
 
-    logger.info("Legend: Ln = line n, Cn = column n, En = error n")
+    if (config.showLegend && problems().nonEmpty)
+      logger.info("Legend: Ln = line n, Cn = column n, En = error n")
   }
 
   override def problems(): Array[xsbti.Problem] =

--- a/src/main/scala/sbt/errorssummary/ConciseReporter.scala
+++ b/src/main/scala/sbt/errorssummary/ConciseReporter.scala
@@ -66,6 +66,8 @@ private class ConciseReporter(logger: Logger,
             log(line)
           }
       }
+
+    logger.info("Legend: Ln = line n, Cn = column n, En = error n")
   }
 
   override def problems(): Array[xsbti.Problem] =
@@ -161,15 +163,31 @@ private class ConciseReporter(logger: Logger,
     val noString = Option.empty[String]
     val (position, lineContent, pointer, prefix) =
       file.fold((noString, noString, noString, "")) { f =>
-        val showLine =
-          line.fold("")(l => s"${colored(colorFor(problem), l.toString)}:")
-        val showCol =
-          if (config.columnNumbers) offset.fold("")(c => s"${c + 1}:") else ""
-        val position =
-          s"""${colored(config.sourcePathColor, f)}:$showLine$showCol"""
-        val lineContent = Some(problem.position.lineContent).filter(_.nonEmpty)
-        val pointer     = problem.position.pointerSpace.map(sp => s"$sp^")
-        val prefix      = s"${extraSpace(problem.severity)}[${problem.id}] "
+        val lineCol = {
+          val lineText = line.fold("") { l =>
+            colored(colorFor(problem), s"L$l:")
+          }
+
+          val colText =
+            offset.filter(_ => config.columnNumbers).fold("") { c =>
+              s"C${c + 1}:"
+            }
+
+          s"$lineText$colText"
+        }
+
+        val position = colored(config.sourcePathColor, f)
+        val lineContent =
+          Option(problem.position.lineContent)
+            .filter(_.nonEmpty)
+            .map(prefixed(lineCol, _))
+
+        val pointer = problem.position.pointerSpace.map { sp =>
+          prefixed(lineCol, s"$sp^")
+        }
+
+        val prefix = s"${extraSpace(problem.severity)}[E${problem.id}] "
+
         (Some(position), lineContent, pointer, prefix)
       }
 
@@ -178,7 +196,6 @@ private class ConciseReporter(logger: Logger,
         .mkString(EOL)
 
     prefixed(prefix, text)
-
   }
 
   private def extraSpace(severity: Severity): String =
@@ -210,8 +227,9 @@ private class ConciseReporter(logger: Logger,
   private def showProblemLine(problem: Problem): Option[String] =
     problem.position.pline.map { line =>
       val color = colorFor(problem)
-      colored(color, line.toString) + colored(config.errorIdColor,
-                                              s" [${problem.id}]")
+
+      colored(color, "L" + line) +
+        colored(config.errorIdColor, s" [E${problem.id}]")
     }
 
   private def nextID(): Int = {

--- a/src/test/scala/sbt/errorssummary/BasicConciseReporterSpec.scala
+++ b/src/test/scala/sbt/errorssummary/BasicConciseReporterSpec.scala
@@ -172,12 +172,27 @@ class BasicConciseReporterSpec
       """    error
         |moreError""".stripMargin
     val configWithReversedOrder = defaultConfig.withReverseOrder(true)
-    val expectedText            = "[2] /tmp/src.scala:2:"
+    val expectedText            = "[E2] /tmp/src.scala"
 
     collectMessagesFor(code, configWithReversedOrder) { (problems, messages) =>
       problems should have length 2
 
-      messages should have length 3
+      messages should have length 4
+      val (_, msg) = messages.head
+      val lines    = msg.split(EOL)
+      lines(0) shouldBe expectedText
+    }
+  }
+
+  it should "not show the legend when told not to" in {
+    val code                = "error"
+    val configWithoutLegend = defaultConfig.withShowLegend(false)
+    val expectedText        = "[E1] /tmp/src.scala"
+
+    collectMessagesFor(code, configWithoutLegend) { (problems, messages) =>
+      problems should have length 1
+
+      messages should have length 2
       val (_, msg) = messages.head
       val lines    = msg.split(EOL)
       lines(0) shouldBe expectedText

--- a/src/test/scala/sbt/errorssummary/BasicConciseReporterSpec.scala
+++ b/src/test/scala/sbt/errorssummary/BasicConciseReporterSpec.scala
@@ -13,7 +13,7 @@ class BasicConciseReporterSpec
   s"A `ConciseReporter` running $scalaVersion" should "collect errors" in collectMessagesFor(
     "foobar") { (problems, messages) =>
     problems should have length 1
-    messages should have length 2
+    messages should have length 3
 
     val problem = problems(0)
 
@@ -28,7 +28,7 @@ class BasicConciseReporterSpec
       |     eventMore""".stripMargin
   } { (problems, messages) =>
     problems should have length 3
-    messages should have length 4
+    messages should have length 5
 
     problems(0).severity shouldBe Severity.Error
     problems(0).position.line.get shouldBe 1
@@ -45,7 +45,7 @@ class BasicConciseReporterSpec
       |     error""".stripMargin
   } { (problems, messages) =>
     problems should have length 1
-    messages should have length 2
+    messages should have length 3
 
     problems(0).severity shouldBe Severity.Error
     problems(0).position.line.get shouldBe 2
@@ -57,7 +57,7 @@ class BasicConciseReporterSpec
       |}""".stripMargin
   } { (problems, messages) =>
     problems should have length 1
-    messages should have length 2
+    messages should have length 3
 
     problems(0).severity shouldBe Severity.Error
     problems(0).position.line.get shouldBe 2
@@ -67,12 +67,12 @@ class BasicConciseReporterSpec
     val code                = """error"""
     val configWithColors    = defaultConfig.withColors(true)
     val configWithoutColors = defaultConfig.withColors(false)
-    val expectedText        = "[1] /tmp/src.scala:1:"
+    val expectedText        = "[E1] /tmp/src.scala"
 
     collectMessagesFor(code, configWithColors) { (problems, messages) =>
       problems should have length 1
 
-      messages should have length 2
+      messages should have length 3
       val (_, msg) = messages.head
       val lines    = msg.split(EOL)
       lines(0).length should be > expectedText.length
@@ -81,7 +81,7 @@ class BasicConciseReporterSpec
     collectMessagesFor(code, configWithoutColors) { (problems, messages) =>
       problems should have length 1
 
-      messages should have length 2
+      messages should have length 3
       val (_, msg) = messages.head
       val lines    = msg.split(EOL)
       lines(0) shouldBe expectedText
@@ -91,60 +91,59 @@ class BasicConciseReporterSpec
   it should "strip prefix if told to" in {
     val code                     = """error"""
     val configWithShortenedPaths = defaultConfig.withShortenPaths(true)
-    val expectedText             = "[1] src.scala:1:"
+    val expectedText             = "[E1] src.scala"
 
-    collectMessagesFor(code, configWithShortenedPaths) {
-      (problems, messages) =>
-        problems should have length 1
+    collectMessagesFor(code, configWithShortenedPaths) { (problems, messages) =>
+      problems should have length 1
 
-        messages should have length 2
-        val (_, msg) = messages.head
-        val lines    = msg.split(EOL)
-        lines(0) shouldBe expectedText
+      messages should have length 3
+      val (_, msg) = messages.head
+      val lines    = msg.split(EOL)
+      lines(0) shouldBe expectedText
     }
   }
 
   it should "not strip prefix if told not to" in {
     val code                        = """error"""
     val configWithoutShortenedPaths = defaultConfig.withShortenPaths(false)
-    val expectedText                = "[1] /tmp/src.scala:1:"
+    val expectedText                = "[E1] /tmp/src.scala"
 
     collectMessagesFor(code, configWithoutShortenedPaths) {
       (problems, messages) =>
         problems should have length 1
 
-        messages should have length 2
+        messages should have length 3
         val (_, msg) = messages.head
         val lines    = msg.split(EOL)
         lines(0) shouldBe expectedText
     }
   }
 
-  it should "not show colum numbers when told not to" in {
+  it should "not show column numbers when told not to" in {
     val code                       = """error"""
     val configWithoutColumnNumbers = defaultConfig.withColumnNumbers(false)
-    val expectedText               = "[1] /tmp/src.scala:1:"
+    val expectedText               = "[E1] /tmp/src.scala"
 
     collectMessagesFor(code, configWithoutColumnNumbers) {
       (problems, messages) =>
         problems should have length 1
 
-        messages should have length 2
+        messages should have length 3
         val (_, msg) = messages.head
         val lines    = msg.split(EOL)
         lines(0) shouldBe expectedText
     }
   }
 
-  it should "show colum numbers when told to" in {
+  it should "show column numbers when told to" in {
     val code                    = """    error""".stripMargin
     val configWithColumnNumbers = defaultConfig.withColumnNumbers(true)
-    val expectedText            = "[1] /tmp/src.scala:1:5:"
+    val expectedText            = "[E1] /tmp/src.scala"
 
     collectMessagesFor(code, configWithColumnNumbers) { (problems, messages) =>
       problems should have length 1
 
-      messages should have length 2
+      messages should have length 3
       val (_, msg) = messages.head
       val lines    = msg.split(EOL)
       lines(0) shouldBe expectedText
@@ -158,7 +157,7 @@ class BasicConciseReporterSpec
     collectMessagesFor(code, filePath = Maybe.nothing[String]) {
       (problems, messages) =>
         problems should have length 1
-        messages should have length 1
+        messages should have length 2
         val (sev, msg) = messages.head
         sev shouldBe Level.Warn
 


### PR DESCRIPTION
The string manipulation logic should be good, but I've never developed or tested an sbt plugin before, so would appreciate some help with the testing.