### PR TITLE
Fix #13: Don't shorten path in IntelliJ, ENSIME

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,11 @@ The supported configuration options include:
    reporterConfig := reporterConfig.value.withShortenPaths(false)
    ```
 
+   Note (0.6.4+): For compatibility with IntelliJ and ENSIME's sbt-mode, the paths will never be shortened when:
+    - the system property `idea.run` is set, or
+    - the environment variable `INSIDE_EMACS` is set, or
+    - the system property `sbt.errorssummary.full.paths` is set.
+
  - `columnNumbers: Boolean = false`:
    Determines whether the reporter will show the column number at which an error has been
    recorded, Defaults to `false`.

--- a/src/main/scala/sbt/errorssummary/Plugin.scala
+++ b/src/main/scala/sbt/errorssummary/Plugin.scala
@@ -34,10 +34,20 @@ object Plugin extends AutoPlugin {
 
   private val reporterSettings = Seq(
     compilerReporter in compile := {
-      val logger  = streams.value.log
-      val baseDir = sys.props("user.dir") + File.separator
-      val spms    = Defaults.foldMappers(sourcePositionMappers.value)
-      val config  = (reporterConfig in compile).value
+      val logger     = streams.value.log
+      val baseDir    = sys.props("user.dir") + File.separator
+      val spms       = Defaults.foldMappers(sourcePositionMappers.value)
+      val baseConfig = (reporterConfig in compile).value
+
+      // When run in intellij, Emacs or when `sbti.errorssummary.full.paths = true`,
+      // don't shorten paths.
+      val forceFullPaths =
+        sys.props.contains("idea.runid") ||
+          sys.env.contains("INSIDE_EMACS") ||
+          sys.props.getOrElse("sbt.errorssummary.full.paths", "") == "true"
+
+      val config =
+        baseConfig.withShortenPaths(baseConfig.shortenPaths && !forceFullPaths)
 
       val reporter =
         new Reporter(logger, baseDir, spms, config)


### PR DESCRIPTION
The reporter configuration will now assume `shortenPaths = false` when
the system property `idea.run` is set, or the environment variable
`INSIDE_EMACS` is set, or the system property
`sbt.errorssummary.full.paths` is set.

Fixes #13